### PR TITLE
feat: upgrade TLS provider to v4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ needed for client auth or server auth or any other usage.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_pkcs12"></a> [pkcs12](#requirement\_pkcs12) | ~> 0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
@@ -19,7 +19,7 @@ needed for client auth or server auth or any other usage.
 |------|---------|
 | <a name="provider_pkcs12"></a> [pkcs12](#provider\_pkcs12) | ~> 0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,6 @@ resource "tls_private_key" "certificate" {
 
 resource "tls_cert_request" "certificate" {
   for_each        = var.certificates
-  key_algorithm   = tls_private_key.certificate[each.key].algorithm
   private_key_pem = tls_private_key.certificate[each.key].private_key_pem
 
   subject {
@@ -68,7 +67,6 @@ resource "tls_cert_request" "certificate" {
 resource "tls_locally_signed_cert" "certificate" {
   for_each           = var.certificates
   cert_request_pem   = tls_cert_request.certificate[each.key].cert_request_pem
-  ca_key_algorithm   = tls_private_key.ca.algorithm
   ca_private_key_pem = tls_private_key.ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
 

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 3"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: upgrade TLS provider to v4.0 and remove deprecated
options

Signed-off-by: Kevin Lefevre <kevin@particule.io>
